### PR TITLE
Fix for django-cms toolbar conflict

### DIFF
--- a/emencia/django/newsletter/templates/newsletter/newsletter_statistics.html
+++ b/emencia/django/newsletter/templates/newsletter/newsletter_statistics.html
@@ -22,7 +22,7 @@ OFC.jquery = {
     popup: function(src) {
         var img_win = window.open('', 'Charts: Export as Image')
         with(img_win.document) {
-            write('<html><head><title>Charts: Export as Image<\/title><\/head><body>' + OFC.jquery.image(src) + '<\/body><\/html>') }
+            write('<html><head><title>Charts: Export as Image<\/title><\/head><bo' + 'dy>' + OFC.jquery.image(src) + '<\/body><\/html>') }
 		  // stop the 'loading...' message
 		  img_win.document.close();
      }


### PR DESCRIPTION
django-cms simply scans generated page for <body> tag and injects its toolbar after it (see cms.middleware.toolbar.insert_after_tag) - this causes trouble on newsletter stats page as toolbar gets injected in the middle of javascript block. Here's a simple fix for that.
