### PR TITLE
A simple option to turn off HTML prettify

### DIFF
--- a/emencia/django/newsletter/settings.py
+++ b/emencia/django/newsletter/settings.py
@@ -14,6 +14,8 @@ USE_UTM_TAGS = getattr(settings, 'NEWSLETTER_USE_UTM_TAGS', True)
 USE_TINYMCE = getattr(settings, 'NEWSLETTER_USE_TINYMCE',
                       'tinymce' in settings.INSTALLED_APPS)
 
+USE_PRETTIFY = getattr(settings, 'NEWSLETTER_USE_PRETTIFY', True)
+
 MAILER_HARD_LIMIT = getattr(settings, 'NEWSLETTER_MAILER_HARD_LIMIT', 10000)
 
 INCLUDE_UNSUBSCRIPTION = getattr(settings, 'NEWSLETTER_INCLUDE_UNSUBSCRIPTION', True)

--- a/emencia/django/newsletter/utils/newsletter.py
+++ b/emencia/django/newsletter/utils/newsletter.py
@@ -3,7 +3,7 @@ from BeautifulSoup import BeautifulSoup
 from django.core.urlresolvers import reverse
 
 from emencia.django.newsletter.models import Link
-
+from emencia.django.newsletter.settings import USE_PRETTIFY
 
 def body_insertion(content, insertion, end=False):
     """Insert an HTML content into the body HTML node"""
@@ -15,7 +15,11 @@ def body_insertion(content, insertion, end=False):
         soup.body.append(insertion)
     else:
         soup.body.insert(0, insertion)
-    return soup.prettify()
+
+    if USE_PRETTIFY:
+        return soup.prettify()
+    else:
+        return soup.renderContents()
 
 
 def track_links(content, context):
@@ -36,4 +40,7 @@ def track_links(content, context):
                                                                               args=[context['newsletter'].slug,
                                                                                     context['uidb36'], context['token'],
                                                                                     link.pk]))
-    return soup.prettify()
+    if USE_PRETTIFY:
+        return soup.prettify()
+    else:
+        return soup.renderContents()


### PR DESCRIPTION
I need the ability to turn the prettifyer off, because the additional white space that is generated by Beautiful soup's prettify can cause Internet Explorer to render additional non-wanted margins in tables.

With this patch you can simply add 

```
NEWSLETTER_USE_PRETTIFY = False
```

to your settings, and you're safe!

(this addresses https://github.com/Fantomas42/emencia-django-newsletter/issues/42)
