### PR TITLE
fixed 999 sqlite3 variable limitation crashing the newsletter creation

### DIFF
--- a/emencia/django/newsletter/admin/contact.py
+++ b/emencia/django/newsletter/admin/contact.py
@@ -95,7 +95,7 @@ class ContactAdmin(admin.ModelAdmin):
         new_mailing = MailingList(name=_('New mailinglist at %s') % when,
                                   description=_('New mailing list created in admin at %s') % when)
         new_mailing.save()
-        new_mailing.subscribers = queryset.all()
+        new_mailing.subscribers = queryset.none()
 
         if not request.user.is_superuser and USE_WORKGROUPS:
             for workgroup in request_workgroups(request):


### PR DESCRIPTION
By default all available newsletter contacts are selected during mailing list creation which causes a  sqlite3 variable limitation crash, to avoid this the code has been modified so no contacts are automatically added and hence the sqlite3 limitation is only triggered when attempting to save.
