### PR TITLE
Fixes Contact Import Function for Django 1.4

### DIFF
--- a/emencia/django/newsletter/admin/contact.py
+++ b/emencia/django/newsletter/admin/contact.py
@@ -137,7 +137,7 @@ class ContactAdmin(admin.ModelAdmin):
 
         context = {'title': _('Contact importation'),
                    'opts': opts,
-                   'root_path': self.admin_site.root_path,
+                   #'root_path': reverse('admin', current_app=opts.app_label),
                    'app_label': opts.app_label}
 
         return render_to_response('newsletter/contact_import.html',

--- a/emencia/django/newsletter/admin/contact.py
+++ b/emencia/django/newsletter/admin/contact.py
@@ -137,7 +137,6 @@ class ContactAdmin(admin.ModelAdmin):
 
         context = {'title': _('Contact importation'),
                    'opts': opts,
-                   #'root_path': reverse('admin', current_app=opts.app_label),
                    'app_label': opts.app_label}
 
         return render_to_response('newsletter/contact_import.html',

--- a/emencia/django/newsletter/management/commands/send_newsletter.py
+++ b/emencia/django/newsletter/management/commands/send_newsletter.py
@@ -31,7 +31,8 @@ class Command(NoArgsCommand):
                     # * alter tests to address encoding
                     
                     #print 'Start emailing %s' % newsletter.title
-                    print 'Start emailing %s' % newsletter.id
+                    print 'Start emailing %s' % unicode(newsletter.id,
+                                                        encoding='utf-8')
                 mailer.run()
 
         if verbose:

--- a/emencia/django/newsletter/management/commands/send_newsletter.py
+++ b/emencia/django/newsletter/management/commands/send_newsletter.py
@@ -24,7 +24,14 @@ class Command(NoArgsCommand):
             mailer = Mailer(newsletter, verbose=verbose)
             if mailer.can_send:
                 if verbose:
-                    print 'Start emailing %s' % newsletter.title
+                    # TODO:
+                    #
+                    # * implement proper logging
+                    #
+                    # * alter tests to address encoding
+                    
+                    #print 'Start emailing %s' % newsletter.title
+                    print 'Start emailing %s' % newsletter.id
                 mailer.run()
 
         if verbose:

--- a/emencia/django/newsletter/templates/newsletter/contact_import.html
+++ b/emencia/django/newsletter/templates/newsletter/contact_import.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n adminmedia %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 {% if not is_popup %}
@@ -12,7 +12,7 @@
 {% endif %}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}admin/css/forms.css" />{% endblock %}
 
 {% block content %}
 <div id="content-main">

--- a/emencia/django/newsletter/utils/newsletter.py
+++ b/emencia/django/newsletter/utils/newsletter.py
@@ -11,6 +11,7 @@ def body_insertion(content, insertion, end=False):
     if not content.startswith('<body'):
         content = '<body>%s</body>' % content
     soup = BeautifulSoup(content)
+    insertion = BeautifulSoup(insertion)
 
     if end:
         soup.body.append(insertion)


### PR DESCRIPTION
fixes contact import app for django 1.4. root_path template var is deprecated and is not used in template. Template now loading css from static url
