### PR TITLE
Django 1.4 timezone support with aware datetime with naive datetime

### DIFF
--- a/emencia/django/newsletter/mailer.py
+++ b/emencia/django/newsletter/mailer.py
@@ -194,8 +194,14 @@ class NewsLetterSender(object):
         """Check if the newsletter can be sent"""
         if self.test:
             return True
+        
+        try:
+            from django.utils.timezone import utc
+            now = datetime.utcnow().replace(tzinfo=utc)
+        except:
+            now = datetime.now()
 
-        if self.newsletter.sending_date <= datetime.now() and \
+        if self.newsletter.sending_date <= now and \
                (self.newsletter.status == Newsletter.WAITING or \
                 self.newsletter.status == Newsletter.SENDING):
             return True


### PR DESCRIPTION
Bugfix with Django 1.4 while comparing aware datetime with naive datetime while executing send_newsletter command.

For more information see https://docs.djangoproject.com/en/dev/topics/i18n/timezones/
