### PR TITLE
Track only http links

### DIFF
--- a/emencia/django/newsletter/utils/newsletter.py
+++ b/emencia/django/newsletter/utils/newsletter.py
@@ -34,13 +34,14 @@ def track_links(content, context):
         if link_markup.get('href') and \
                'no-track' not in link_markup.get('rel', ''):
             link_href = link_markup['href']
-            link_title = link_markup.get('title', link_href)
-            link, created = Link.objects.get_or_create(url=link_href,
-                                                       defaults={'title': link_title})
-            link_markup['href'] = 'http://%s%s' % (context['domain'], reverse('newsletter_newsletter_tracking_link',
-                                                                              args=[context['newsletter'].slug,
-                                                                                    context['uidb36'], context['token'],
-                                                                                    link.pk]))
+            if link_href.startswith("http"):
+                link_title = link_markup.get('title', link_href)
+                link, created = Link.objects.get_or_create(url=link_href,
+                                                           defaults={'title': link_title})
+                link_markup['href'] = 'http://%s%s' % (context['domain'], reverse('newsletter_newsletter_tracking_link',
+                                                                                  args=[context['newsletter'].slug,
+                                                                                        context['uidb36'], context['token'],
+                                                                                        link.pk]))
     if USE_PRETTIFY:
         return soup.prettify()
     else:


### PR DESCRIPTION
The only sensible link to track are `http` based ones.
`mailto`, `javascript` and other protocols are not 'trackable'
This removes the tracking from all butt `http(s)` links
