### PR TITLE
Add Content-ID header for attachments

### DIFF
--- a/emencia/django/newsletter/mailer.py
+++ b/emencia/django/newsletter/mailer.py
@@ -140,6 +140,9 @@ class NewsLetterSender(object):
                 message_attachment.set_payload(fd.read())
                 encode_base64(message_attachment)
             fd.close()
+            if attachment.title:
+                message_attachment.add_header('Content-ID',
+                                              "<%s>" % attachment.title)
             message_attachment.add_header('Content-Disposition', 'attachment',
                                           filename=attachment.title)
             attachments.append(message_attachment)


### PR DESCRIPTION
images can be referenced in message body by attachment title:

&lt;img src="cid:IMAGENAME"&gt;
