### PR TITLE
Site view and unsubscribe link need not to be escaped when included into...

### DIFF
--- a/emencia/django/newsletter/models.py
+++ b/emencia/django/newsletter/models.py
@@ -3,6 +3,7 @@ from smtplib import SMTP
 from smtplib import SMTPHeloError
 from datetime import datetime
 from datetime import timedelta
+from email.header import Header
 
 from django.db import models
 from django.utils.encoding import smart_str
@@ -138,7 +139,7 @@ class Contact(models.Model):
 
     def mail_format(self):
         if self.first_name and self.last_name:
-            return '%s %s <%s>' % (self.last_name, self.first_name, self.email)
+            return Header('%s %s <%s>' % (self.last_name, self.first_name, self.email), 'utf-8').encode()
         return self.email
     mail_format.short_description = _('mail format')
 

--- a/emencia/django/newsletter/utils/newsletter.py
+++ b/emencia/django/newsletter/utils/newsletter.py
@@ -11,11 +11,12 @@ def body_insertion(content, insertion, end=False):
     if not content.startswith('<body'):
         content = '<body>%s</body>' % content
     soup = BeautifulSoup(content)
+    soup_ins = BeautifulSoup(insertion)
 
     if end:
-        soup.body.append(insertion)
+        soup.body.append(soup_ins)
     else:
-        soup.body.insert(0, insertion)
+        soup.body.insert(0, soup_ins)
 
     if USE_PRETTIFY:
         return soup.prettify()

--- a/emencia/django/newsletter/views/tracking.py
+++ b/emencia/django/newsletter/views/tracking.py
@@ -1,6 +1,6 @@
 """Views for emencia.django.newsletter Tracking"""
 import base64
-from urllib import urlencode
+from django.utils.http import urlencode
 from urlparse import urlparse
 from urlparse import urlunparse
 # For Python < 2.6
@@ -53,9 +53,9 @@ def view_newsletter_tracking_link(request, slug, uidb36, token, link_id):
     query_dict = parse_qs(url_parts.query)
     query_dict.update({'utm_source': 'newsletter_%s' % newsletter.pk,
                        'utm_medium': 'mail',
-                       'utm_campaign': smart_str(newsletter.title)})
+                       'utm_campaign': newsletter.title})
     url = urlunparse((url_parts.scheme, url_parts.netloc, url_parts.path,
-                      url_parts.params, urlencode(query_dict), url_parts.fragment))
+                      url_parts.params, urlencode(query_dict, True), url_parts.fragment))
     return HttpResponseRedirect(url)
 
 


### PR DESCRIPTION
Site view and unsubscribe link need not to be escaped when included in the body of newsletter

Call to BeatifulSoap changed to avoid HTML escaping of included content.
